### PR TITLE
[QSP-20 Fix] Ensure recipient smart contract not ready do not receive our tokens

### DIFF
--- a/contracts/wallet.scilla
+++ b/contracts/wallet.scilla
@@ -213,7 +213,7 @@ let custom_token_transaction_msg_as_list =
          _tag : "proxyBurn" ;
          _amount : Uint128 0 ;
          value : value }
-      | Mint to value =>
+      | Mint =>
         (* Mint             (to : ByStr20, value : Uint128)  *)
         {_recipient : proxyTokenContract ;
          _tag : "proxyMint" ;

--- a/contracts/wallet.scilla
+++ b/contracts/wallet.scilla
@@ -699,7 +699,7 @@ end
 transition RecipientAcceptTransfer (sender : ByStr20, recipient : ByStr20, amount : Uint128)
 end
 
-(* Callback transition - no action required, but must be defined, since transferFrom will fail otherwise. *)
+(* Callback transition - no action required, but must be defined, since transferFroms from the wallet will fail otherwise. *)
 transition TransferFromSuccessCallBack (sender : ByStr20, recipient : ByStr20, amount : Uint128)
 end
 

--- a/contracts/wallet.scilla
+++ b/contracts/wallet.scilla
@@ -207,7 +207,7 @@ let custom_token_transaction_msg_as_list =
         {_recipient : proxyTokenContract ;
          _tag : "proxyPause" ;
          _amount : Uint128 0 }
-      | Burn value =>
+      | Burn =>
         (* Burn             (value : Uint128)  *)
         {_recipient : proxyTokenContract ;
          _tag : "proxyBurn" ;

--- a/contracts/wallet.scilla
+++ b/contracts/wallet.scilla
@@ -207,13 +207,13 @@ let custom_token_transaction_msg_as_list =
         {_recipient : proxyTokenContract ;
          _tag : "proxyPause" ;
          _amount : Uint128 0 }
-      | Burn =>
+      | Burn value =>
         (* Burn             (value : Uint128)  *)
         {_recipient : proxyTokenContract ;
          _tag : "proxyBurn" ;
          _amount : Uint128 0 ;
          value : value }
-      | Mint =>
+      | Mint to value =>
         (* Mint             (to : ByStr20, value : Uint128)  *)
         {_recipient : proxyTokenContract ;
          _tag : "proxyMint" ;
@@ -701,4 +701,8 @@ end
 
 (* Callback transition - no action required, but must be defined, since transferFrom will fail otherwise. *)
 transition TransferFromSuccessCallBack (sender : ByStr20, recipient : ByStr20, amount : Uint128)
+end
+
+(* Acceptance transition - no action required, but must be defined, since transfers to the wallet will fail otherwise. *)
+transition RecipientAcceptTransferFrom (sender : ByStr20, recipient : ByStr20, amount : Uint128)
 end

--- a/contracts/wallet.scilla
+++ b/contracts/wallet.scilla
@@ -691,8 +691,12 @@ transition AddFunds ()
   accept
 end
 
-(* Callback transition - no action required, but must be defined, since transfer will fail otherwise. *)
+(* Callback transition - no action required, but must be defined, since transfers from the wallet will fail otherwise. *)
 transition TransferSuccessCallBack (sender : ByStr20, recipient : ByStr20, amount : Uint128)
+end
+
+(* Acceptance transition - no action required, but must be defined, since transfers to the wallet will fail otherwise. *)
+transition RecipientAcceptTransfer (sender : ByStr20, recipient : ByStr20, amount : Uint128)
 end
 
 (* Callback transition - no action required, but must be defined, since transferFrom will fail otherwise. *)

--- a/contracts/xsgd_contract.scilla
+++ b/contracts/xsgd_contract.scilla
@@ -375,7 +375,7 @@ transition lawEnforcementWipingBurn(address : ByStr20, initiator : ByStr20)
       | Some b =>
         balances[address] := zero;
         currentSupply <- totalSupply;
-        new_supply = builtin sub currentSupply b;
+        new_supply = builtin sub currentSupply bal;
         totalSupply := new_supply;
         e = { _eventname : "lawEnforcementWipingBurnt"; blacklister : initiator; address : address; amount : bal};
         event e

--- a/contracts/xsgd_contract.scilla
+++ b/contracts/xsgd_contract.scilla
@@ -25,6 +25,11 @@ let one_msg =
     fun (msg : Message) =>
         let nil_msg = Nil {Message} in
         Cons {Message} msg nil_msg
+let two_msgs =
+  fun (msg1 : Message) =>
+  fun (msg2 : Message) =>
+    let msgs_tmp = one_msg msg1 in
+    Cons {Message} msg2 msgs_tmp
 let f_eq =
   fun (a : ByStr20) =>
   fun (b : ByStr20) =>
@@ -440,9 +445,11 @@ transition transfer(to : ByStr20, value : Uint128, initiator : ByStr20)
             balances[to] := new_to_bal;
             e = {_eventname : "Transfer"; sender : initiator; recipient : to; amount : value};
             event e;
-            msg = {_tag : "TransferSuccessCallBack"; _recipient : initiator; _amount : zero;
-                   sender : initiator; recipient : to; amount : value};
-            msgs = one_msg msg;
+            msg_to_recipient = {_tag : "RecipientAcceptTransfer"; _recipient : to; _amount : zero;
+                                sender : initiator; recipient : to; amount : value};
+            msg_to_sender = {_tag : "TransferSuccessCallBack"; _recipient : initiator; _amount : zero;
+                             sender : initiator; recipient : to; amount : value};
+            msgs = two_msgs msg_to_recipient msg_to_sender;
             send msgs
           | False =>
             e = { _eventname : "transfer FailedInsufficientBalance"; to : to; value: value; sender : initiator};

--- a/contracts/xsgd_contract.scilla
+++ b/contracts/xsgd_contract.scilla
@@ -379,6 +379,7 @@ transition lawEnforcementWipingBurn(address : ByStr20, initiator : ByStr20)
         totalSupply := new_supply;
         e = { _eventname : "lawEnforcementWipingBurnt"; blacklister : initiator; address : address; amount : bal};
         event e
+      end
       | None =>
         e = { _eventname : "lawEnforcementWipingBurn FailedNoBalance"; address : address; sender : initiator};
         event e

--- a/contracts/xsgd_contract.scilla
+++ b/contracts/xsgd_contract.scilla
@@ -28,8 +28,8 @@ let one_msg =
 let two_msgs =
   fun (msg1 : Message) =>
   fun (msg2 : Message) =>
-    let msgs_tmp = one_msg msg1 in
-    Cons {Message} msg2 msgs_tmp
+    let msgs_tmp = one_msg msg2 in
+    Cons {Message} msg1 msgs_tmp
 let f_eq =
   fun (a : ByStr20) =>
   fun (b : ByStr20) =>
@@ -375,11 +375,10 @@ transition lawEnforcementWipingBurn(address : ByStr20, initiator : ByStr20)
       | Some b =>
         balances[address] := zero;
         currentSupply <- totalSupply;
-        new_supply = builtin sub currentSupply bal;
+        new_supply = builtin sub currentSupply b;
         totalSupply := new_supply;
         e = { _eventname : "lawEnforcementWipingBurnt"; blacklister : initiator; address : address; amount : bal};
         event e
-      end
       | None =>
         e = { _eventname : "lawEnforcementWipingBurn FailedNoBalance"; address : address; sender : initiator};
         event e
@@ -503,9 +502,11 @@ transition transferFrom (from : ByStr20, to : ByStr20, value : Uint128, initiato
             allowed[from][initiator] := new_allowed;
             e = {_eventname : "TransferFromSuccess"; recipient : to; sender : from; initiator : initiator; amount : value};
             event e;
-            msg = {_tag : "TransferFromSuccessCallBack"; _recipient : initiator; _amount : zero;
-                   sender : from; recipient : to; amount : value };
-            msgs = one_msg msg;
+            msg_to_recipient = {_tag : "RecipientAcceptTransferFrom"; _recipient : to; _amount : zero;
+                                sender : from; recipient : to; amount : value};
+            msg_to_sender = {_tag : "TransferFromSuccessCallBack"; _recipient : initiator; _amount : zero;
+                             sender : from; recipient : to; amount : value };
+            msgs = two_msgs msg_to_recipient msg_to_sender;
             send msgs
           | False =>
             e = { _eventname : "transferFrom FailedInsufficientBalance"; to : to; from : from; value: value; sender : initiator};


### PR DESCRIPTION
`transfer` and `transferFrom` now sends messages not only to the sender, but also to the recipient. This is to ensure that tokens don't end up belonging to contracts who don't have the functionality to transfer them onwards.

Note that the order of the messages is important. The message to the recipient must be sent first, because that send may fail, in which case it would be incorrect to notify the sender that the transfer went through.